### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,5 +1,7 @@
 ---
 name: pull request
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/code-gorilla-au/pyrotic/security/code-scanning/1](https://github.com/code-gorilla-au/pyrotic/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow. Since the job only checks out code, installs tools, and runs tests/lint/scan, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This can be set either at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job requires different permissions. Therefore, add the following block after the `name:` field and before the `on:` field in `.github/workflows/pull-request.yaml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
